### PR TITLE
chore(docker): add dockerignores for builds and fuzzing

### DIFF
--- a/.clusterfuzzlite/.dockerignore
+++ b/.clusterfuzzlite/.dockerignore
@@ -1,0 +1,12 @@
+# Python cache and build artifacts
+**/__pycache__
+**/.pytest_cache
+**/*.egg-info
+
+# Development files
+.git
+.github
+.gitignore
+.ruff_cache
+.venv
+build/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Python cache and build artifacts
+**/__pycache__
+**/.pytest_cache
+**/*.egg-info


### PR DESCRIPTION
Adds .dockerignore files to exclude Python artifacts and development files from both main and clusterfuzzlite container builds.
