### PR TITLE
feat(metrics): add /metrics endpoint for Prometheus metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "requests>=2.32.3,<2.33.0",
     "httpx>=0.28.1,<0.29.0",
     "exceptiongroup>=1.2.2,<1.3.0",
+    "prometheus-client>=0.21.1,<0.22.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -185,6 +185,10 @@ pluggy==1.5.0 \
     --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \
     --hash=sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
     # via pytest
+prometheus-client==0.21.1 \
+    --hash=sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb \
+    --hash=sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301
+    # via hivebox (pyproject.toml)
 pydantic==2.10.6 \
     --hash=sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584 \
     --hash=sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,6 +144,10 @@ idna==3.10 \
     #   anyio
     #   httpx
     #   requests
+prometheus-client==0.21.1 \
+    --hash=sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb \
+    --hash=sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301
+    # via hivebox (pyproject.toml)
 pydantic==2.10.6 \
     --hash=sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584 \
     --hash=sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236

--- a/src/hivebox/__init__.py
+++ b/src/hivebox/__init__.py
@@ -1,6 +1,6 @@
 """Hivebox package configuration and shared utilities."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 SENSE_BOX_IDS = [
     '62abdbfbb91502001b7c05a8',

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,9 @@
 """Main entry point for the application."""
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from hivebox import __version__
 from hivebox.temperature import get_average_temperature
+import prometheus_client
 
 app = FastAPI()
 
@@ -16,6 +17,13 @@ async def get_temperature():
     """Get average temperature."""
     return {"temperature": get_average_temperature()}
 
+@app.get("/metrics")
+async def metrics():
+    """Expose Prometheus metrics."""
+    return Response(
+        content=prometheus_client.generate_latest(),
+        media_type="text/plain"
+    )
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
### Summary
Add `/metrics` endpoint returning default Prometheus metrics with no parameters.
