### PR TITLE
security/fix sonarqube issues

### DIFF
--- a/k8s/hivebox-deploy.yaml
+++ b/k8s/hivebox-deploy.yaml
@@ -24,6 +24,13 @@ spec:
         imagePullPolicy: Never
         ports:
         - containerPort: 8000
+        resources:
+          requests:
+            cpu: 100m
+            memory: 90Mi
+          limits:
+            cpu: 200m
+            memory: 180Mi
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/hivebox-deploy.yaml
+++ b/k8s/hivebox-deploy.yaml
@@ -31,6 +31,7 @@ spec:
           limits:
             cpu: 200m
             memory: 180Mi
+      automountServiceAccountToken: false
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/nginx-deploy.yaml
+++ b/k8s/nginx-deploy.yaml
@@ -369,6 +369,9 @@ spec:
           requests:
             cpu: 100m
             memory: 90Mi
+          limits:
+            cpu: 200m
+            memory: 180Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
- Adding resource limits (CPU: 200m, Memory: 180Mi) to prevent resource exhaustion
- Disabling service account token automounting
- Applied to both hivebox and nginx deployments

Resolves SonarQube security findings.