### PR TITLE
chore(ci): split workflow into separate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,14 @@ on:
 permissions: read-all
 
 jobs:
-  verify:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+      - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
         with:
           fetch-depth: 0
 
-      - name: Setup Python
-        uses: actions/setup-python@d0b4fc497a1daddb64da40799d80949aa3a0c559 
+      - uses: actions/setup-python@d0b4fc497a1daddb64da40799d80949aa3a0c559
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -33,13 +31,35 @@ jobs:
         run: pylint --fail-under=8 src/
 
       - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@d292784f8f3eacda47060b259a580467b0ba410c 
+        uses: hadolint/hadolint-action@d292784f8f3eacda47060b259a580467b0ba410c
         with:
           dockerfile: Dockerfile
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+
+      - uses: actions/setup-python@d0b4fc497a1daddb64da40799d80949aa3a0c559
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: '**/pyproject.toml'
+
+      - name: Install dependencies
+        run: pip install --require-hashes -r requirements-dev.txt
 
       - name: Run unit tests
         run: |
           PYTHONPATH=$PYTHONPATH:$(pwd)/src pytest src/tests
+
+  sonarqube:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+        with:
+          fetch-depth: 0
 
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@v4
@@ -54,12 +74,24 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+  build-and-verify:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
+
+      - uses: actions/setup-python@d0b4fc497a1daddb64da40799d80949aa3a0c559
+        with:
+          python-version: '3.11'
+
       - name: Build Docker image
         run: docker build -t hivebox:test .
 
+      - name: Install package
+        run: pip install .
+
       - name: Test version endpoint
         run: |
-          pip install .
           docker run -d -p 8000:8000 --name hivebox-test hivebox:test
           sleep 5
           EXPECTED_VERSION=$(python -c "from hivebox import __version__; print(__version__)")


### PR DESCRIPTION
- Separate lint, test, sonarqube, and build jobs
- Enable parallel execution of lint and test jobs
- Add explicit job dependencies using `needs`
- Preserve all existing functionality and checks
