### PR TITLE
chore(ci): add Terrascan IaC security scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
         uses: hadolint/hadolint-action@d292784f8f3eacda47060b259a580467b0ba410c
         with:
           dockerfile: Dockerfile
+      - name: Scan IaC
+        uses: tenable/terrascan-action@3a6e87da8e244513bd77b631e624552643f794c6
+        with:
+          iac_type: 'k8s'
+          iac_dir: 'k8s'
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add Terrascan to lint job for IaC security analysis
- Configure scanning for Dockerfile, K8s manifests and Terraform
- Run in parallel with existing linting tasks